### PR TITLE
Update heading to Building Your App

### DIFF
--- a/docs/building_your_app.md
+++ b/docs/building_your_app.md
@@ -1,4 +1,4 @@
-# Building you app
+# Building your app
  electron-vue makes use of [electron-userland/electron-packager](https://github.com/electron-userland/electron-packager) to produce builds and are then saved to `builds`.
 
 ## Defaults


### PR DESCRIPTION
since the filename is `building_your_app`, I believe this should be corrected.