### PR TITLE
Update for Electron Packager 8.0.0

### DIFF
--- a/docs/building_your_app.md
+++ b/docs/building_your_app.md
@@ -4,9 +4,6 @@
 ## Defaults
 ```js
 {
-    // `app/package.json` version
-    'app-version': pkg.version,
-
     // Target 'x64' architecture
     arch: 'x64',
 

--- a/template/config.js
+++ b/template/config.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const path = require('path')
-const pkg = require('./app/package.json')
 
 let config = {
   // Name of electron app
@@ -20,7 +19,6 @@ let config = {
   // electron-packager options
   // Docs: https://simulatedgreg.gitbooks.io/electron-vue/content/docs/building_your_app.html
   building: {
-    'app-version': pkg.version,
     arch: 'x64',
     asar: true,
     dir: path.join(__dirname, 'app'),

--- a/template/package.json
+++ b/template/package.json
@@ -34,7 +34,7 @@
     "devtron": "^1.1.0",
     "electron": "^1.3.1",
     "electron-devtools-installer": "^1.1.4",
-    "electron-packager": "^7.6.0",
+    "electron-packager": "^8.0.0",
     "electron-rebuild": "^1.1.3",
     {{#eslint}}
     "eslint": "^2.10.2",


### PR DESCRIPTION
Electron Packager [8.0.0](https://github.com/electron-userland/electron-packager/releases/tag/v8.0.0) was released today. This PR upgrades `electron-packager` and removes the need to manually set the app version (as of [7.7.0](https://github.com/electron-userland/electron-packager/releases/tag/v7.7.0), it is inferred from the app's `package.json` if it is not specified).