### PR TITLE
Tweak whitespace in tasks/release.js to comply with js-standard

### DIFF
--- a/template/tasks/release.js
+++ b/template/tasks/release.js
@@ -20,7 +20,6 @@ function pack () {
   pack.on('exit', code => build())
 }
 
-
 /**
  * Use electron-packager to build electron app
  */
@@ -29,7 +28,7 @@ function build () {
 
   console.log('\x1b[34mBuilding electron app(s)...\n\x1b[0m')
   packager(options, (err, appPaths) => {
-    if(err) {
+    if (err) {
       console.error('\x1b[31mError from `electron-packager` when building app...\x1b[0m')
       console.error(err)
     } else {


### PR DESCRIPTION
The rest of tasks/release.js is formatted according to js-standard, and this prevents the only two linting errors in the project that appear when using js-standard style.