### PR TITLE
Ignore unit-test-generated coverage directory

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -2,6 +2,7 @@
 app/dist/index.html
 app/dist/build.js
 builds/*
+coverage
 node_modules
 npm-debug.log
 npm-debug.log.*


### PR DESCRIPTION
I'm used to seeing coverage directories gitignored. Would this be something ***you*** want projects to gitignore by default?