### PR TITLE
Alphabetize the template's root package.json devDependencies

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -40,7 +40,13 @@
     "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
+    {{#if e2e}}
+    "babel-register": "^6.14.0",
+    {{/if}}
     "babel-runtime": "^6.6.1",
+    {{#testing unit e2e}}
+    "chai": "^3.5.0",
+    {{/testing}}
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",
     "del": "^2.2.1",
@@ -51,11 +57,13 @@
     "electron-rebuild": "^1.1.3",
     {{#eslint}}
     "eslint": "^2.10.2",
+    {{#if_eq eslintConfig 'standard'}}
+    "eslint-config-standard": "^5.1.0",
+    {{/if_eq}}
     "eslint-friendly-formatter": "^2.0.5",
     "eslint-loader": "^1.3.0",
     "eslint-plugin-html": "^1.3.0",
     {{#if_eq eslintConfig 'standard'}}
-    "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.0.8",
     "eslint-plugin-standard": "^1.3.2",
     {{/if_eq}}
@@ -67,10 +75,12 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
     "html-webpack-plugin": "^2.16.1",
-    "json-loader": "^0.5.4",
     {{#if unit}}
     "inject-loader": "^2.0.1",
     "isparta-loader": "^2.0.0",
+    {{/if}}
+    "json-loader": "^0.5.4",
+    {{#if unit}}
     "karma": "^1.3.0",
     "karma-chai": "^0.1.0",
     "karma-coverage": "^1.1.1",
@@ -79,17 +89,14 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^1.8.0",
-    "webpack-merge": "^0.14.1",
     {{/if}}
+    {{#testing unit e2e}}
+    "mocha": "^3.0.2",
+    {{/testing}}
     {{#if e2e}}
-    "babel-register": "^6.14.0",
     "require-dir": "^0.3.0",
     "spectron": "^3.4.0",
     {{/if}}
-    {{#testing unit e2e}}
-    "chai": "^3.5.0",
-    "mocha": "^3.0.2",
-    {{/testing}}
     "style-loader": "^0.13.1",
     "tree-kill": "^1.1.0",
     "url-loader": "^0.5.7",
@@ -98,7 +105,10 @@
     {{ver vueVersion 'loader'}}
     "vue-style-loader": "^1.0.0",
     "webpack": "^1.13.0",
-    "webpack-dev-server": "^1.14.1"
+    "webpack-dev-server": "^1.14.1"{{#if unit}},{{/if}}
+    {{#if unit}}
+    "webpack-merge": "^0.14.1"
+    {{/if}}
   },
   "dependencies": {}
 }


### PR DESCRIPTION
This takes the load off users to alphabetize the dependencies.

Since npm automatically alphabetizes the dependencies on `npm install --save-dev`, this prevents users from committing alphabetization noise when they git-commit their first project-specific dependency.