### PR TITLE
Fix template/package.json to a specific version of Electron

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -45,7 +45,7 @@
     "css-loader": "^0.23.1",
     "del": "^2.2.1",
     "devtron": "^1.1.0",
-    "electron": "^1.3.1",
+    "electron": "1.3.1",
     "electron-devtools-installer": "^1.1.4",
     "electron-packager": "^8.0.0",
     "electron-rebuild": "^1.1.3",


### PR DESCRIPTION
The Electron docs recommend referencing a specific version of Electron, as Electron does not follow Semantic Versioning:
http://electron.atom.io/docs/tutorial/electron-versioning/