### PR TITLE
Update template .gitignore to ignore compiled CSS

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 app/dist/index.html
 app/dist/build.js
+app/dist/styles.css
 builds/*
 {{#if unit}}
 coverage


### PR DESCRIPTION
Don't track the webpack-compiled-distributed CSS.