### PR TITLE
Remove leftover SCSS usage in template Links.vue

### DIFF
--- a/template/app/src/components/LandingPageView/Links.vue
+++ b/template/app/src/components/LandingPageView/Links.vue
@@ -2,8 +2,10 @@
   a {
     color: rgb(50, 174, 110);
     text-decoration: none;
-
-    &:hover { color: rgb(40, 56, 76); }
+  }
+  
+  a:hover { 
+    color: rgb(40, 56, 76); 
   }
 
   ul {


### PR DESCRIPTION
Closes #77

`node-sass` was removed for Windows build compatibility. This removes use of leftover SCSS in the `Links.vue` component.