### PR TITLE
fix duplicate babel-register

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -134,7 +134,6 @@
     "webpack-merge": "^2.4.0",
     {{/if}}
     {{#if e2e}}
-    "babel-register": "^6.14.0",
     "require-dir": "^0.3.0",
     "spectron": "^3.4.0",
     {{/if}}


### PR DESCRIPTION
`babel-register` shows up twice when you choose `e2e`, which is incorrect.