### PR TITLE
Simple update to fix image path issues.

### DIFF
--- a/template/config.js
+++ b/template/config.js
@@ -17,6 +17,8 @@ let config = {
   eslint: true,
 
 {{/if}}
+  //image path for use with url-loader
+  imgPath: 'imgs/[path][name].[ext]',
   // webpack-dev-server port
   port: 9080{{#if_eq builder 'packager'}},
 

--- a/template/config.js
+++ b/template/config.js
@@ -18,7 +18,7 @@ let config = {
 
 {{/if}}
   //image path for use with url-loader
-  imgPath: 'imgs/[path][name].[ext]',
+  imgPath: 'imgs/[name].[hash:4].[ext]',
   // webpack-dev-server port
   port: 9080{{#if_eq builder 'packager'}},
 

--- a/template/webpack.renderer.config.js
+++ b/template/webpack.renderer.config.js
@@ -58,7 +58,7 @@ let rendererConfig = {
         loader: 'url-loader',
         query: {
           limit: 10000,
-          name: 'imgs/[name].[ext]'
+          name: 'imgs/[path][name].[ext]'
         }
       },
       {

--- a/template/webpack.renderer.config.js
+++ b/template/webpack.renderer.config.js
@@ -58,7 +58,7 @@ let rendererConfig = {
         loader: 'url-loader',
         query: {
           limit: 10000,
-          name: 'imgs/[path][name].[ext]'
+          name: settings.imgPath
         }
       },
       {


### PR DESCRIPTION
This is a simple update to add path's into webpacks `url-loader` to better handle more advanced needs for images.

Currently if you have 2 images with the same name that are over 10kb it can load the incorrect image. Given the size of many applications and also typical folder/naming structures this is very possible (I spent hours trying to figure this out for myself).