### PR TITLE
print error code when unable to load url

### DIFF
--- a/template/app/src/main/index.js
+++ b/template/app/src/main/index.js
@@ -2,6 +2,13 @@
 
 import { app, BrowserWindow } from 'electron'
 
+const RED = '\x1b[31m'
+const BLUE = '\x1b[34m'
+const YELLOW = '\x1b[33m'
+const END = '\x1b[0m'
+
+const colorize = (str, color, bold = false) => (bold ? '\u001b[1m' : '') + color + str + END
+
 let mainWindow
 const winURL = process.env.NODE_ENV === 'development'
   ? `http://localhost:${require('../../../config').port}`
@@ -14,6 +21,13 @@ function createWindow () {
   mainWindow = new BrowserWindow({
     height: 600,
     width: 800
+  })
+
+  mainWindow.webContents.on('did-fail-load', (_, errCode) => {
+    let suggestion = errCode === -324 ? 'Please check if you have some proxy settings\n' : ''
+    let msg = `${colorize('Error: ', RED)} did fail to load URL ${colorize(winURL, YELLOW)} since errCode ${colorize(errCode, RED)}
+${colorize(suggestion, YELLOW, true)}For more details please see ${colorize('https://electron.atom.io/docs/api/web-contents/#event-did-fail-load', BLUE)}`
+    console.log(msg)
   })
 
   mainWindow.loadURL(winURL)


### PR DESCRIPTION
Hi,

Thank you for this helpful project.

I use `npm run dev` to begin my coding, then I'm given a blank page with no error information, after some google I find that's caused by my system proxy, it results in the BrowserWindow gets an empty response from dev server. So I hope this pull request could give some help to someone else have the same issue.