### PR TITLE
Fixed karma-coverage reporting no data

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -29,7 +29,7 @@
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}",
     {{/testing}}
     {{#if unit}}
-    "unit": "cross-env BABEL_ENV=testing-unit karma start test/unit/karma.conf.js",
+    "unit": "karma start test/unit/karma.conf.js",
     {{/if}}
     "postinstall": "{{#if eslint}}npm run lint:fix && {{/if}}cd app && npm install"
   },

--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -7,6 +7,9 @@ const webpack = require('webpack')
 const baseConfig = require('../../webpack.renderer.config')
 const projectRoot = path.resolve(__dirname, '../../app')
 
+// Set BABEL_ENV to use proper preset config
+process.env.BABEL_ENV = 'testing-unit'
+
 let webpackConfig = merge(baseConfig, {
   devtool: '#inline-source-map',
   plugins: [


### PR DESCRIPTION
The BABEL_ENV which was getting set for testing was getting overwritten by the BABEL_ENV set in webpack.renderer.config.js. Fixed it by declaring the BABEL_ENV in the karma config, similar to how it is done for e2e testing.

This should fix #181 and istanbul should generate correct coverage reports now.