### PR TITLE
Fix eslint errors in generated webpack files

### DIFF
--- a/template/webpack.main.config.js
+++ b/template/webpack.main.config.js
@@ -4,7 +4,6 @@ process.env.BABEL_ENV = 'main'
 
 const path = require('path')
 const pkg = require('./app/package.json')
-const settings = require('./config.js')
 const webpack = require('webpack')
 
 let mainConfig = {

--- a/template/webpack.renderer.config.js
+++ b/template/webpack.renderer.config.js
@@ -85,7 +85,7 @@ let rendererConfig = {
       template: './app/index.ejs',
       appModules: process.env.NODE_ENV !== 'production'
         ? path.resolve(__dirname, 'app/node_modules')
-        : false,
+        : false
     }),
     new webpack.NoEmitOnErrorsPlugin()
   ],


### PR DESCRIPTION
The settings is the main config file never used.

And in the renderer config there that comma is indeed dangling.