### PR TITLE
Fix CopyWebpackPlugin config for both dev and production

### DIFF
--- a/template/.electron-vue/webpack.renderer.config.js
+++ b/template/.electron-vue/webpack.renderer.config.js
@@ -91,6 +91,13 @@ let rendererConfig = {
         ? path.resolve(__dirname, '../node_modules')
         : false
     }),
+    new CopyWebpackPlugin([
+      {
+        from: path.join(__dirname, '../static'),
+        to: path.join(__dirname, '../dist/electron/static'),
+        ignore: ['.*']
+      }
+    ]),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin()
   ],

--- a/template/.electron-vue/webpack.web.config.js
+++ b/template/.electron-vue/webpack.web.config.js
@@ -90,6 +90,13 @@ let webConfig = {
         ? path.resolve(__dirname, '../node_modules')
         : false
     }),
+    new CopyWebpackPlugin([
+      {
+        from: path.join(__dirname, '../static'),
+        to: path.join(__dirname, '../dist/web/static'),
+        ignore: ['.*']
+      }
+    ]),
     new webpack.DefinePlugin({
       'process.env.IS_WEB': 'true'
     }),


### PR DESCRIPTION
Solves the new bug in #198 (static assets not appearing in development).

CopyWebpackPlugin needs to be present both in development and production for this structure to work.

I tested with a new project with several static assets and it works in both development and production.

Thanks Greg!