### PR TITLE
Add a stderr handler in dev-runner.js.

### DIFF
--- a/template/.electron-vue/dev-runner.js
+++ b/template/.electron-vue/dev-runner.js
@@ -130,6 +130,22 @@ function startElectron () {
       )
     }
   })
+  electronProcess.stderr.on('data', data => {
+    let log = ''
+    data = data.toString().split(/\r?\n/)
+    data.forEach(line => {
+      log += `  ${line}\n`
+    })
+    if (/[0-9A-z]+/.test(data[0])) {
+      console.log(
+        chalk.red.bold('┏ Electron -------------------') +
+        '\n\n' +
+        log +
+        chalk.red.bold('┗ ----------------------------') +
+        '\n'
+      )
+    }
+  })
 
   electronProcess.on('close', () => {
     if (!manualRestart) process.exit()

--- a/template/.electron-vue/webpack.renderer.config.js
+++ b/template/.electron-vue/webpack.renderer.config.js
@@ -130,7 +130,7 @@ let rendererConfig = {
 }
 
 /**
- * Adjust mainConfig for development settings
+ * Adjust rendererConfig for development settings
  */
 if (process.env.NODE_ENV !== 'production') {
   rendererConfig.plugins.push(

--- a/template/package.json
+++ b/template/package.json
@@ -119,7 +119,7 @@
     "eslint-plugin-standard": "^3.0.1",
     {{/if_eq}}
     {{#if_eq eslintConfig 'airbnb'}}
-    "eslint-config-airbnb-base": "^11.1.3",
+    "eslint-config-airbnb-base": "^11.2.0",
     "eslint-import-resolver-webpack": "^0.8.1",
     "eslint-plugin-import": "^2.2.0",
     {{/if_eq}}
@@ -143,7 +143,7 @@
     {{/if}}
     {{#if e2e}}
     "require-dir": "^0.3.0",
-    "spectron": "^3.6.4",
+    "spectron": "^3.7.1",
     {{/if}}
     {{#testing unit e2e}}
     "chai": "^4.0.0",


### PR DESCRIPTION
Add a stderr handler in dev-runner script in order to capture the outputs of console.warn and console.error as well.

In addition, update some dependencies and fix a typo in webpack.renderer.config.js.