### PR TITLE
update travis/appveyor to use latest OS version

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -107,14 +107,14 @@ module.exports = {
       message: 'What build tool would you like to use?',
       choices: [
         {
-          name: 'electron-packager (https://github.com/electron-userland/electron-packager)',
-          value: 'packager',
-          short: 'packager'
-        },
-        {
           name: 'electron-builder (https://github.com/electron-userland/electron-builder)',
           value: 'builder',
           short: 'builder'
+        },
+        {
+          name: 'electron-packager (https://github.com/electron-userland/electron-packager)',
+          value: 'packager',
+          short: 'packager'
         }
       ]
     }

--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -2,7 +2,7 @@
 # Commented sections below can be used to run tests on the CI server
 # https://simulatedgreg.gitbooks.io/electron-vue/content/en/testing.html#on-the-subject-of-ci-testing
 {{/testing}}
-osx_image: xcode8
+osx_image: xcode8.3
 sudo: required
 dist: trusty
 language: c

--- a/template/appveyor.yml
+++ b/template/appveyor.yml
@@ -8,6 +8,7 @@ branches:
   only:
     - master
 
+image: Visual Studio 2017
 platform:
   - x64
 
@@ -21,7 +22,7 @@ init:
   - git config --global core.autocrlf input
 
 install:
-  - ps: Install-Product node 7 x64
+  - ps: Install-Product node 8 x64
   - choco install yarn --ignore-dependencies
   - git reset --hard HEAD
   - yarn
@@ -31,6 +32,6 @@ build_script:
 {{#testing unit e2e}}
   #- yarn test
 {{/testing}}
-  - yarn run build
+  - yarn build
 
 test: off

--- a/template/package.json
+++ b/template/package.json
@@ -16,8 +16,8 @@
     "build:mas": "cross-env BUILD_TARGET=mas node .electron-vue/build.js",
     "build:win32": "cross-env BUILD_TARGET=win32 node .electron-vue/build.js",
     {{else}}
-    "build": "node .electron-vue/build.js && build",
-    "build:dir": "node .electron-vue/build.js && build --dir",
+    "build": "node .electron-vue/build.js && electron-builder",
+    "build:dir": "node .electron-vue/build.js && electron-builder --dir",
     {{/if_eq}}
     "build:clean": "cross-env BUILD_TARGET=clean node .electron-vue/build.js",
     "build:web": "cross-env BUILD_TARGET=web node .electron-vue/build.js",
@@ -48,9 +48,7 @@
       "output": "build"
     },
     "files": [
-      "dist/electron",
-      "node_modules/",
-      "package.json"
+      "dist/electron/**/*"
     ],
     "dmg": {
       "contents": [
@@ -101,10 +99,10 @@
     "electron-devtools-installer": "^2.0.1",
     {{#if_eq builder 'packager'}}
     "electron-packager": "^8.5.0",
-    {{else}}
-    "electron-builder": "^18.1.0",
-    {{/if_eq}}
     "electron-rebuild": "^1.1.3",
+    {{else}}
+    "electron-builder": "^19.10.0",
+    {{/if_eq}}
     {{#eslint}}
     "babel-eslint": "^7.0.0",
     "eslint": "^3.13.1",


### PR DESCRIPTION
update electron-builder to 19.x
make electron-builder as default choice because electron-builder handles all aspects of building Electron app (and in any case by alphabet)

1. electron-builder and electron-osx-sign fully support macOS Sierra.
2. electron-builder 19.6.0 bundles wine and all other tools to build electron app for Windows on macOS without setup, but macOS Sierra is required.
3. macOS Sierra is required to sign DMG.
4. Windows Server 2016 should be used to build appx. Yes — electron-builder bundles all required tools, but in any case it is better to use Windows Server 2016.
5. The same OS version locally and on CI.

electron-rebuild dependency is removed if electron-builder used — useless dependency.

JFYI: electron-builder app, Electrify, will use this boilerplate (https://github.com/electron-userland/electron-builder/issues/1706), so, I will bother you and send isssues/PR :) Thanks for excellent boilerplate.