### PR TITLE
updated to the latest version of electron builder

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -102,7 +102,7 @@
     {{#if_eq builder 'packager'}}
     "electron-packager": "^8.5.0",
     {{else}}
-    "electron-builder": "^18.1.0",
+    "electron-builder": "^19.8.0",
     {{/if_eq}}
     "electron-rebuild": "^1.1.3",
     {{#eslint}}


### PR DESCRIPTION
### Description
When opting to use Electron Builder npm install fails due to the template using an older version of electron builder. That version of electron builder points to an old version of fcopy-pre-bundled which fails on the node-gyp rebuild step. Here is the log output

> 120551 verbose stack Error: fcopy-pre-bundled@0.1.2 install: `node-gyp rebuild`
> 120551 verbose stack Exit status 1
> 120551 verbose stack     at EventEmitter.<anonymous> (/Users/user/.nvm/versions/node/v7.10.0/lib/node_modules/npm/lib/utils/lifecycle.js:279:16)
> 120551 verbose stack     at emitTwo (events.js:106:13)
> 120551 verbose stack     at EventEmitter.emit (events.js:194:7)
> 120551 verbose stack     at ChildProcess.<anonymous> (/Users/user/.nvm/versions/node/v7.10.0/lib/node_modules/npm/lib/utils/spawn.js:40:14)
> 120551 verbose stack     at emitTwo (events.js:106:13)
> 120551 verbose stack     at ChildProcess.emit (events.js:194:7)
> 120551 verbose stack     at maybeClose (internal/child_process.js:899:16)
> 120551 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
> 120552 verbose pkgid fcopy-pre-bundled@0.1.2
> 120553 verbose cwd /Users/user/Sites/adobe-stock-installation/electron-test-project
> 120554 error Darwin 16.6.0
> 120555 error argv "/Users/user/.nvm/versions/node/v7.10.0/bin/node" "/Users/user/.nvm/versions/node/v7.10.0/bin/npm" "install"
> 120556 error node v7.10.0
> 120557 error npm  v4.2.0
> 120558 error code ELIFECYCLE
> 120559 error errno 1
> 120560 error fcopy-pre-bundled@0.1.2 install: `node-gyp rebuild`
> 120560 error Exit status 1
> 120561 error Failed at the fcopy-pre-bundled@0.1.2 install script 'node-gyp rebuild'.
> 120561 error Make sure you have the latest version of node.js and npm installed.
> 120561 error If you do, this is most likely a problem with the fcopy-pre-bundled package,
> 120561 error not with npm itself.
> 120561 error Tell the author that this fails on your system:
> 120561 error     node-gyp rebuild
> 120561 error You can get information on how to open an issue for this project with:
> 120561 error     npm bugs fcopy-pre-bundled
> 120561 error Or if that isn't available, you can get their info via:
> 120561 error     npm owner ls fcopy-pre-bundled
> 120561 error There is likely additional logging output above.
> 120562 verbose exit [ 1, true ]

### Environment:
Operating System: macOS Sierra (10.12.5)
node: v7.10.0
npm: v4.2.0

### Reproducible steps
1. `$ vue init simulatedgreg/electron-vue my-project`
2. `$ cd my-project && npm install`

### Changes
The only change is to package.json in the templates folder. Updates to the current version of electron-builder