### PR TITLE
fix the `setup` option is deprecated.

### DIFF
--- a/template/.electron-vue/dev-runner.js
+++ b/template/.electron-vue/dev-runner.js
@@ -64,7 +64,7 @@ function startRenderer () {
       {
         contentBase: path.join(__dirname, '../'),
         quiet: true,
-        setup (app, ctx) {
+        before (app, ctx) {
           app.use(hotMiddleware)
           ctx.middleware.waitUntilValid(() => {
             resolve()


### PR DESCRIPTION
The `setup` option is deprecated and will be removed in v3. Please update your config to use `before`