### PR TITLE
fix appveyor install yarn error

### DIFF
--- a/template/appveyor.yml
+++ b/template/appveyor.yml
@@ -23,7 +23,6 @@ init:
 
 install:
   - ps: Install-Product node 8 x64
-  - choco install yarn --ignore-dependencies
   - git reset --hard HEAD
   - yarn
   - node --version


### PR DESCRIPTION
Yarn is pre-installed with appveyor.
https://www.appveyor.com/updates/

![image](https://user-images.githubusercontent.com/7029338/33465212-698503c2-d681-11e7-9328-b5dab9d70960.png)
