### PR TITLE
Install git-lfs nicely

### DIFF
--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -26,9 +26,7 @@ addons:
     #- xvfb
 {{/testing}}
 before_install:
-- mkdir -p /tmp/git-lfs && curl -L https://github.com/github/git-lfs/releases/download/v1.2.1/git-lfs-$([
-  "$TRAVIS_OS_NAME" == "linux" ] && echo "linux" || echo "darwin")-amd64-1.2.1.tar.gz
-  | tar -xz -C /tmp/git-lfs --strip-components 1 && /tmp/git-lfs/git-lfs pull
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install git-lfs; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install --no-install-recommends -y icnsutils graphicsmagick xz-utils; fi
 install:
 {{#testing unit e2e}}


### PR DESCRIPTION
due to Travis CI has a [guide](https://docs.travis-ci.com/user/customizing-the-build/#Git-LFS) to handle Git LFS, we should change this or it may cause problem under osx sometimes. ([like this](https://travis-ci.org/LightouchDev/MasterVyrn/jobs/302319564))

Git LFS is installed on Trusty by default.