### PR TITLE
Added Pomotroid app to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,4 @@ Take a look at some of the amazing projects built with electron-vue. Want to hav
 * [**Opshell**](https://github.com/ricktbaker/opshell): Ops tool to make life easier working with AWS instances.
 * [**GitHoard**](https://github.com/jojobyte/githoard): Hoard git repositories with ease.
 * [**Data-curator**](https://github.com/ODIQueensland/data-curator): Share usable open data.
+* [**Pomotroid**](https://github.com/Splode/pomotroid): A simple and visually-pleasing Pomodoro timer


### PR DESCRIPTION
Added Pomotroid app, built with electron-vue, to the _Made with electron-vue_ section in the README. Thanks for the framework! It's a real pleasure to work with.