### PR TITLE
Remove yarn installation step for AppVeyor

### DIFF
--- a/template/appveyor.yml
+++ b/template/appveyor.yml
@@ -23,7 +23,6 @@ init:
 
 install:
   - ps: Install-Product node 8 x64
-  - choco install yarn --ignore-dependencies
   - git reset --hard HEAD
   - yarn
   - node --version


### PR DESCRIPTION
All AppVeyor builds seem to be failing at the step where we try to install `yarn` through `chocolatey`. After some investigation (primarily from [here](https://help.appveyor.com/discussions/problems/9054-cannot-install-yarn-with-choco)), I found out that this was because `yarn` is preinstalled ever since [this](https://www.appveyor.com/updates/2017/10/22/) update.

Hence, the installation step is not only unnecessary, but it also results in guaranteed build failure, hence we should remove it.