### PR TITLE
Fix app.getVersion() getting electron lib version #375

### DIFF
--- a/template/.electron-vue/dev-runner.js
+++ b/template/.electron-vue/dev-runner.js
@@ -114,7 +114,7 @@ function startMain () {
 }
 
 function startElectron () {
-  electronProcess = spawn(electron, ['--inspect=5858', path.join(__dirname, '../dist/electron/main.js')])
+  electronProcess = spawn(electron, ['--inspect=5858', '.'])
 
   electronProcess.stdout.on('data', data => {
     electronLog(data, 'blue')


### PR DESCRIPTION
In development mode, it fetches electrons version instead of app's version which is in pacakage.json. (as #375 )

```js
// src/main/index.js

import { app } from 'electron'
console.log('getVersion', app.getVersion()) // getVersion 1.7.12
```
![image](https://user-images.githubusercontent.com/11560552/36040539-b558f48c-0e00-11e8-877a-32bde220d4c2.png)

And, I find a solution from [electron/electron#7085](https://github.com/electron/electron/issues/7085)

> In development the version returned by app.getVersion() depends on how you launched your app.

I got the right Version of App when I change the path from `path.join(__dirname, '../dist/electron/main.js')` to `'.'`

![image](https://user-images.githubusercontent.com/11560552/36041614-0a884824-0e04-11e8-93c7-7e9bcf3a9200.png)

![image](https://user-images.githubusercontent.com/11560552/36041102-7edc7dd2-0e02-11e8-8ab4-7a9d6f1a2fba.png)

This issue confuse me alot when I using `electron-updater`.

-------

* Electron version: 1.7.12
* Node version: 7.9.0
* NPM version: 5.6.0
* Platform: win32
* Vue-cli version: 2.9.3