### PR TITLE
Add support for FORCE_COLOR environment variable

### DIFF
--- a/template/.electron-vue/build.js
+++ b/template/.electron-vue/build.js
@@ -21,12 +21,8 @@ const webConfig = require('./webpack.web.config')
 const doneLog = chalk.bgGreen.white(' DONE ') + ' '
 const errorLog = chalk.bgRed.white(' ERROR ') + ' '
 const okayLog = chalk.bgBlue.white(' OKAY ') + ' '
+const colors = (process.env.FORCE_COLOR == 0) ? false : true
 const isCI = process.env.CI || false
-
-let colors = true
-if (process.env.FORCE_COLOR !== undefined) {
-  colors = !!parseInt(process.env.FORCE_COLOR)
-}
 
 if (process.env.BUILD_TARGET === 'clean') clean()
 else if (process.env.BUILD_TARGET === 'web') web()

--- a/template/.electron-vue/build.js
+++ b/template/.electron-vue/build.js
@@ -23,6 +23,11 @@ const errorLog = chalk.bgRed.white(' ERROR ') + ' '
 const okayLog = chalk.bgBlue.white(' OKAY ') + ' '
 const isCI = process.env.CI || false
 
+let colors = true
+if (process.env.FORCE_COLOR !== undefined) {
+  colors = !!parseInt(process.env.FORCE_COLOR)
+}
+
 if (process.env.BUILD_TARGET === 'clean') clean()
 else if (process.env.BUILD_TARGET === 'web') web()
 else build()
@@ -83,7 +88,7 @@ function pack (config) {
 
         stats.toString({
           chunks: false,
-          colors: true
+          colors
         })
         .split(/\r?\n/)
         .forEach(line => {
@@ -94,7 +99,7 @@ function pack (config) {
       } else {
         resolve(stats.toString({
           chunks: false,
-          colors: true
+          colors
         }))
       }
     })
@@ -121,7 +126,7 @@ function web () {
 
     console.log(stats.toString({
       chunks: false,
-      colors: true
+      colors
     }))
 
     process.exit()

--- a/template/.electron-vue/dev-runner.js
+++ b/template/.electron-vue/dev-runner.js
@@ -12,14 +12,10 @@ const webpackHotMiddleware = require('webpack-hot-middleware')
 const mainConfig = require('./webpack.main.config')
 const rendererConfig = require('./webpack.renderer.config')
 
+const colors = (process.env.FORCE_COLOR == 0) ? false : true
 let electronProcess = null
 let manualRestart = false
 let hotMiddleware
-
-let colors = true
-if (process.env.FORCE_COLOR !== undefined) {
-  colors = !!parseInt(process.env.FORCE_COLOR)
-}
 
 function logStats (proc, data) {
   let log = ''

--- a/template/.electron-vue/dev-runner.js
+++ b/template/.electron-vue/dev-runner.js
@@ -16,6 +16,11 @@ let electronProcess = null
 let manualRestart = false
 let hotMiddleware
 
+let colors = true
+if (process.env.FORCE_COLOR !== undefined) {
+  colors = !!parseInt(process.env.FORCE_COLOR)
+}
+
 function logStats (proc, data) {
   let log = ''
 
@@ -24,7 +29,7 @@ function logStats (proc, data) {
 
   if (typeof data === 'object') {
     data.toString({
-      colors: true,
+      colors,
       chunks: false
     }).split(/\r?\n/).forEach(line => {
       log += '  ' + line + '\n'


### PR DESCRIPTION
Chalk allows you to force enable or disable color with the `FORCE_COLOR` environment variable by setting it to 1 or 0. My specific use case is to run a dev build in Sublime Text which does not support color in its console, however this could also be useful for CI, log files, etc. I do still want color when running in a terminal, thus, this PR was born.

Here's the related setting in my `project.sublime-project` file if anyone is interested in doing the same:
```json
"build_systems": [{
	"name": "Dev",
	"shell_cmd": "cross-env FORCE_COLOR=0 npm run dev",
	"working_dir": "<redacted>"
}],
```