### PR TITLE
Update appveyor.yml, remove "choco install yarn ..."

### DIFF
--- a/template/appveyor.yml
+++ b/template/appveyor.yml
@@ -23,7 +23,6 @@ init:
 
 install:
   - ps: Install-Product node 8 x64
-  - choco install yarn --ignore-dependencies
   - git reset --hard HEAD
   - yarn
   - node --version


### PR DESCRIPTION
Remove "choco install yarn --ignore-dependencies" from appveyor.yml

Since Yarn 1.5.1 is already installed on AppVeyor, there is no need to install it again.

It produce a error code 1603 with this line, build success without this line.

source? : [https://www.appveyor.com/docs/build-environment/#pre-installed-software](https://www.appveyor.com/docs/build-environment/#pre-installed-software)