### PR TITLE
Updated dev-runner.js : Commandline Params

### DIFF
--- a/template/.electron-vue/dev-runner.js
+++ b/template/.electron-vue/dev-runner.js
@@ -114,7 +114,13 @@ function startMain () {
 }
 
 function startElectron () {
-  electronProcess = spawn(electron, ['--inspect=5858', path.join(__dirname, '../dist/electron/main.js')])
+ var args = [
+    '--inspect=5858',
+    path.join(__dirname, '../dist/electron/main.js')
+  ]
+  args = args.concat(process.argv.slice(3))
+
+  electronProcess = spawn(electron, args)
 
   electronProcess.stdout.on('data', data => {
     electronLog(data, 'blue')


### PR DESCRIPTION
This change allows you to run `yarn dev run` or `yarn dev run -arg1=a --arg2=b c d e` 

If you give arguments they will be passed into the electron app and accessible via:  `process.argv`

I'm sure there is a more efficient way to write the javascript - but i have tested this with and without args and it works correctly.

This was in response to #581 and once I started looking around I realized it was an easy fix.  