### PR TITLE
add rule no-unused-expressions=off

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -38,5 +38,13 @@ module.exports = {
     {{/if_eq}}
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0
-  }
+  },
+  overrides: [
+    {
+      "files": ["*-test.js", "*.spec.js"],
+      "rules": {
+        "no-unused-expressions": "off"
+      }
+    }
+  ]
 }

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -18,7 +18,8 @@ module.exports = {
     __static: true
   },
   plugins: [
-    'html'
+    'html',
+    'chai-friendly'
   ],
   'rules': {
     {{#if_eq eslintConfig 'standard'}}
@@ -43,7 +44,8 @@ module.exports = {
     {
       "files": ["*-test.js", "*.spec.js"],
       "rules": {
-        "no-unused-expressions": "off"
+        "no-unused-expressions": "off",
+        'chai-friendly/no-unused-expressions': 'off',
       }
     }
   ]

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     sourceType: 'module'
   },
   env: {
+    mocha: process.env.NODE_ENV !== 'production',
     browser: true,
     node: true
   },

--- a/template/package.json
+++ b/template/package.json
@@ -108,6 +108,7 @@
     "eslint": "^4.4.1",
     "eslint-friendly-formatter": "^3.0.0",
     "eslint-loader": "^1.9.0",
+    "eslint-plugin-chai-friendly": "^0.4.1",
     "eslint-plugin-html": "^3.1.1",
     {{#if_eq eslintConfig 'standard'}}
     "eslint-config-standard": "^10.2.1",


### PR DESCRIPTION
some chai tests may trigger the eslint no-used-expressions
```
  ✘  http://eslint.org/docs/rules/no-unused-expressions  Expected an assignment or function call and instead saw an expression
  path/to/test.spec.js:62:9
          expect(await proxy[ID_APPARECCHIO]).to.not.be.undefined
           ^


✘ 1 problem (1 error, 0 warnings)


Errors:
  1  http://eslint.org/docs/rules/no-unused-expressions
```
the solution is a copy & paste from [Eslint docs](https://eslint.org/docs/user-guide/configuring#disabling-rules-only-for-a-group-of-files)