### PR TITLE
fix bugs:

### DIFF
--- a/template/.electron-vue/dev-runner.js
+++ b/template/.electron-vue/dev-runner.js
@@ -1,5 +1,7 @@
 'use strict'
 
+process.env.NODE_ENV = 'production'
+
 const chalk = require('chalk')
 const electron = require('electron')
 const path = require('path')

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     'no-multi-assign': 0,
     {{/if_eq}}
     // allow debugger during development
-    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0
+    // `process.env.NODE_ENV` will get `undefined` when `npm run lint`
+    'no-debugger': process.env.NODE_ENV === 'development' ? 0 : 2
   }
 }


### PR DESCRIPTION
1. `process.env.NODE_ENV` get `undefined` when `npm run lint`
2. won't lint `no-debugger` when `npm run lint`