### PR TITLE
fix: remove hot-module-replacement in production mode

### DIFF
--- a/template/.electron-vue/webpack.renderer.config.js
+++ b/template/.electron-vue/webpack.renderer.config.js
@@ -138,7 +138,6 @@ let rendererConfig = {
         ? path.resolve(__dirname, '../node_modules')
         : false
     }),
-    new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin()
   ],
   output: {
@@ -161,6 +160,7 @@ let rendererConfig = {
  */
 if (process.env.NODE_ENV !== 'production') {
   rendererConfig.plugins.push(
+    new webpack.HotModuleReplacementPlugin(),
     new webpack.DefinePlugin({
       '__static': `"${path.join(__dirname, '../static').replace(/\\/g, '\\\\')}"`
     })


### PR DESCRIPTION
Remove hot-module-replacement related code from the bundled file in the production mode