### PR TITLE
disabled vuex-electron in build:web

### DIFF
--- a/template/src/renderer/store/index.js
+++ b/template/src/renderer/store/index.js
@@ -1,9 +1,6 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 
-{{#isEnabled plugins 'vuex-electron'}}
-import { createPersistedState, createSharedMutations } from 'vuex-electron'
-
 {{/isEnabled}}
 import modules from './modules'
 
@@ -12,9 +9,9 @@ Vue.use(Vuex)
 export default new Vuex.Store({
   modules,
   {{#isEnabled plugins 'vuex-electron'}}
-  plugins: [
-    createPersistedState(),
-    createSharedMutations()
+  plugins: process.env.IS_WEB ? [] : [
+    require('vuex-electron').createPersistedState(),
+    require('vuex-electron').createSharedMutations()
   ],
   {{/isEnabled}}
   strict: process.env.NODE_ENV !== 'production'


### PR DESCRIPTION
If vuex-electron is enabled in build:web, a error, `Uncaught TypeError: n.existsSync is not a function`, occurs when I open the bundled `index.html` in a browser.