### PR TITLE
Fix a bug when using vuex-electron

### DIFF
--- a/template/src/main/index.js
+++ b/template/src/main/index.js
@@ -3,6 +3,9 @@
 
 {{/if_eq}}
 import { app, BrowserWindow } from 'electron'{{#if_eq eslintConfig 'airbnb'}} // eslint-disable-line{{/if_eq}}
+{{#isEnabled plugins 'vuex-electron'}}
+import '../renderer/store'
+{{/isEnabled}}
 
 /**
  * Set `__static` path to static files in production


### PR DESCRIPTION
When using `vuex-electron`, this line of import code helps the `mapActions` function work properly.