### PR TITLE
ESlint emit shows warning insted of error

### DIFF
--- a/template/.electron-vue/webpack.renderer.config.js
+++ b/template/.electron-vue/webpack.renderer.config.js
@@ -39,7 +39,8 @@ let rendererConfig = {
         use: {
           loader: 'eslint-loader',
           options: {
-            formatter: require('eslint-friendly-formatter')
+            formatter: require('eslint-friendly-formatter'),
+            emitWarning: true,
           }
         }
       },


### PR DESCRIPTION
eslint-loader produces error which results in build failure,
instead of producing error warnings are generated so that build process is not hampered