### PR TITLE
Updating documentation about import global

### DIFF
--- a/docs/en/using_pre-processors.md
+++ b/docs/en/using_pre-processors.md
@@ -68,6 +68,19 @@ loaders: {
 }
 ```
 
+In some cases it doesn't work, you may edit `scss` and `sass` directly
+
+```js
+{
+  test: /\.scss$/,
+  use: ['vue-style-loader', 'css-loader', 'sass-loader?data=@import "./src/renderer/globals";']
+},
+{
+  test: /\.sass$/,
+  use: ['vue-style-loader', 'css-loader', 'sass-loader?data=@import "./src/renderer/globals";']
+},
+```
+
 #### Use your globals
 
 **SomeComponent.vue**


### PR DESCRIPTION
A lot of issues talk about global import, if import in vue loader doesn't work, update directly scss and sass.