### PR TITLE
Replace multispinner with listr in build.js

### DIFF
--- a/template/.electron-vue/build.js
+++ b/template/.electron-vue/build.js
@@ -11,7 +11,7 @@ const packager = require('electron-packager')
 const { spawn } = require('child_process')
 {{/if_eq}}
 const webpack = require('webpack')
-const Multispinner = require('multispinner')
+const Listr = require('listr')
 
 {{#if_eq builder 'packager'}}const buildConfig = require('./build.config'){{/if_eq}}
 const mainConfig = require('./webpack.main.config')
@@ -33,7 +33,7 @@ function clean () {
   process.exit()
 }
 
-function build () {
+async function build () {
   greeting()
 
   del.sync(['dist/electron/*', '!.gitkeep'])
@@ -46,32 +46,49 @@ function build () {
 
   let results = ''
 
-  m.on('success', () => {
-    process.stdout.write('\x1B[2J\x1B[0f')
-    console.log(`\n\n${results}`)
-    console.log(`${okayLog}take it away ${chalk.yellow('`electron-{{builder}}`')}\n`)
-    {{#if_eq builder 'packager'}}bundleApp(){{else}}process.exit(){{/if_eq}}
-  })
+  const tasks = new Listr(
+    [
+      {
+        title: 'building master process',
+        task: async () => {
+          await pack(mainConfig)
+            .then(result => {
+              results += result + '\n\n'
+            })
+            .catch(err => {
+              console.log(`\n  ${errorLog}failed to build main process`)
+              console.error(`\n${err}\n`)
+            })
+        }
+      },
+      {
+        title: 'building renderer process',
+        task: async () => {
+          await pack(rendererConfig)
+            .then(result => {
+              results += result + '\n\n'
+            })
+            .catch(err => {
+              console.log(`\n  ${errorLog}failed to build renderer process`)
+              console.error(`\n${err}\n`)
+            })
+        }
+      }
+    ],
+    { concurrent: 2 }
+  )
 
-  pack(mainConfig).then(result => {
-    results += result + '\n\n'
-    m.success('main')
-  }).catch(err => {
-    m.error('main')
-    console.log(`\n  ${errorLog}failed to build main process`)
-    console.error(`\n${err}\n`)
-    process.exit(1)
-  })
-
-  pack(rendererConfig).then(result => {
-    results += result + '\n\n'
-    m.success('renderer')
-  }).catch(err => {
-    m.error('renderer')
-    console.log(`\n  ${errorLog}failed to build renderer process`)
-    console.error(`\n${err}\n`)
-    process.exit(1)
-  })
+  await tasks
+    .run()
+    .then(() => {
+      process.stdout.write('\x1B[2J\x1B[0f')
+      console.log(`\n\n${results}`)
+      console.log(`${okayLog}take it away ${chalk.yellow('`electron-builder`')}\n`)
+      process.exit()
+    })
+    .catch(err => {
+      process.exit(1)
+    })
 }
 
 function pack (config) {

--- a/template/package.json
+++ b/template/package.json
@@ -137,6 +137,7 @@
     "karma-spec-reporter": "^0.0.32",
     "karma-webpack": "^3.0.0",
     {{/if}}
+    "listr": "^0.14.3",
     {{#if e2e}}
     "require-dir": "^1.0.0",
     "spectron": "^3.8.0",
@@ -146,7 +147,6 @@
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
     {{/testing}}
-    "multispinner": "^0.2.1",
     "node-loader": "^0.6.0",
     {{#if usesass}}
     "node-sass": "^4.9.2",


### PR DESCRIPTION
refs #924 

`multispinner` is not maintained, and it has security issues. So I propose replacing `multispinner` with another one.
In this pull request, I am using `listr`. `listr` can execute multiple tasks in parallel, so I think that it is enough to meet this requirement.

I have already used this script in my project, it looks like here:
![Screenshot from 2019-12-31 00-02-45](https://user-images.githubusercontent.com/4631959/71587431-fa097500-2b60-11ea-9b5b-ce411e24927f.png)
