### PR TITLE
fix Travis-CI error using git lfs

### DIFF
--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -26,9 +26,7 @@ addons:
     #- xvfb
 {{/testing}}
 before_install:
-- mkdir -p /tmp/git-lfs && curl -L https://github.com/github/git-lfs/releases/download/v1.2.1/git-lfs-$([
-  "$TRAVIS_OS_NAME" == "linux" ] && echo "linux" || echo "darwin")-amd64-1.2.1.tar.gz
-  | tar -xz -C /tmp/git-lfs --strip-components 1 && /tmp/git-lfs/git-lfs pull
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install git-lfs; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install --no-install-recommends -y icnsutils graphicsmagick xz-utils; fi
 install:
 {{#testing unit e2e}}
@@ -40,6 +38,8 @@ install:
 - source ~/.bashrc
 - npm install -g xvfb-maybe
 - yarn
+before_script:
+- git lfs pull
 script:
 {{#unit}}
 #- xvfb-maybe node_modules/.bin/karma start test/unit/karma.conf.js


### PR DESCRIPTION
Was encountering error in Travis-CI:

```
0.75s$ mkdir -p /tmp/git-lfs && curl -L https://github.com/github/git-lfs/releases/download/v1.2.1/git-lfs-$([ "$TRAVIS_OS_NAME" == "linux" ] && echo "linux" || echo "darwin")-amd64-1.2.1.tar.gz | tar -xz -C /tmp/git-lfs --strip-components 1 && /tmp/git-lfs/git-lfs pull
/Users/travis/.travis/functions: line 109:  2911 Segmentation fault: 11  /tmp/git-lfs/git-lfs pull
The command "mkdir -p /tmp/git-lfs && curl -L https://github.com/github/git-lfs/releases/download/v1.2.1/git-lfs-$([ "$TRAVIS_OS_NAME" == "linux" ] && echo "linux" || echo "darwin")-amd64-1.2.1.tar.gz | tar -xz -C /tmp/git-lfs --strip-components 1 && /tmp/git-lfs/git-lfs pull" failed and exited with 139 during .
```

Travis-CI now supports git-lfs in Linux by default and recommends using brew to install on Mac OSX. (https://docs.travis-ci.com/user/customizing-the-build#macos).

Tested changes on my own project.

Fixes #991 