### PR TITLE
Added IntelTracker to "made with" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,4 @@ Take a look at some of the amazing projects built with electron-vue. Want to hav
 * [**YouGet**](https://github.com/ahmetzeybek/YouGet): YouGet - YouTube Video/Playlist Downloader/Cutter - MP3 Converter
 * [**Asar UI**](https://github.com/myazarc/AsarUI): UI for Asar Pack, built with Electron & Vue.js.
 * [**Leeze**](https://github.com/dayinji/Leeze): A Receipt Record App, built with Electron & Vue.js.
+* [**IntelTracker**](https://github.com/hectate/inteltracker): An intel item tracker for players/speedrunners of NOLF.


### PR DESCRIPTION
IntelTracker is a project intended for players and speed-runners of No One Lives Forever (2000, PC). It tracks what intelligence items are found in the game as the player finds them. It uses ``electron-vue`` to allow it to run locally as an application, with ``vue`` handling UI updates and customization, and save-file watching using ``chokidar``.

Thanks for the great ``electron-vue`` tool; it made initial setup trivially easy!