### PR TITLE
Fix runtime error

### DIFF
--- a/template/.electron-vue/webpack.web.config.js
+++ b/template/.electron-vue/webpack.web.config.js
@@ -99,8 +99,20 @@ let webConfig = {
     new VueLoaderPlugin(),
     new MiniCssExtractPlugin({filename: 'styles.css'}),
     new HtmlWebpackPlugin({
-      filename: 'index.html',
+      filename: 'index.html',                                                                                                                                                                                                                 
       template: path.resolve(__dirname, '../src/index.ejs'),
+      templateParameters(compilation, assets, options) {
+        return {
+          compilation: compilation,
+          webpack: compilation.getStats().toJson(),
+          webpackConfig: compilation.options,
+          htmlWebpackPlugin: {
+            files: assets,
+            options: options
+          },
+          process,
+        };
+      },
       minify: {
         collapseWhitespace: true,
         removeAttributeQuotes: true,


### PR DESCRIPTION
As shown in #1003, due to a configuration file error, a "process is not defined" error may occur at runtime