### PR TITLE
fix: const task was already defined

### DIFF
--- a/template/.electron-vue/build.js
+++ b/template/.electron-vue/build.js
@@ -38,8 +38,8 @@ async function build () {
 
   del.sync(['dist/electron/*', '!.gitkeep'])
 
-  const tasks = ['main', 'renderer']
-  const m = new Multispinner(tasks, {
+  const process_tasks = ['main', 'renderer']
+  const m = new Multispinner(process_tasks, {
     preText: 'building',
     postText: 'process'
   })


### PR DESCRIPTION
Changing the name of the predefined const tasks to prevent error in issue #1076