### PR TITLE
Fix the cause of the build failure.

### DIFF
--- a/template/.electron-vue/build.js
+++ b/template/.electron-vue/build.js
@@ -38,11 +38,11 @@ async function build () {
 
   del.sync(['dist/electron/*', '!.gitkeep'])
 
-  const tasks = ['main', 'renderer']
-  const m = new Multispinner(tasks, {
-    preText: 'building',
-    postText: 'process'
-  })
+  // const tasks = ['main', 'renderer']
+  // const m = new Multispinner(tasks, {
+  //   preText: 'building',
+  //   postText: 'process'
+  // })
 
   let results = ''
 


### PR DESCRIPTION
The following error message will appear when the existing code runs the command 'yarn/npm run build'
Log: Identifier 'tasks' has already been declared.
Successfully build after commenting out the relevant code. Hope someone will make a more perfect repair in the future.