### PR TITLE
delete wrong and redundent codes

### DIFF
--- a/template/.electron-vue/build.js
+++ b/template/.electron-vue/build.js
@@ -38,12 +38,6 @@ async function build () {
 
   del.sync(['dist/electron/*', '!.gitkeep'])
 
-  const tasks = ['main', 'renderer']
-  const m = new Multispinner(tasks, {
-    preText: 'building',
-    postText: 'process'
-  })
-
   let results = ''
 
   const tasks = new Listr(


### PR DESCRIPTION
delete wrong and redundant codes in template/.electron-vue/build.js