### PR TITLE
Remove useless code which was breaking  `npm run build` 

### DIFF
--- a/template/.electron-vue/build.js
+++ b/template/.electron-vue/build.js
@@ -38,12 +38,6 @@ async function build () {
 
   del.sync(['dist/electron/*', '!.gitkeep'])
 
-  const tasks = ['main', 'renderer']
-  const m = new Multispinner(tasks, {
-    preText: 'building',
-    postText: 'process'
-  })
-
   let results = ''
 
   const tasks = new Listr(


### PR DESCRIPTION
This code was forgotten during a commit and was breaking the `npm run build` command.
The problematic PR: #971
