### PR TITLE
Upgrade Dependencies, use Babel 7 and Webpack 5, various fixes

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -4,10 +4,9 @@
 {{#testing unit e2e}}
     "test": {
       "presets": [
-        ["env", {
+        ["@babel/preset-env", {
           "targets": { "node": 7 }
         }],
-        "stage-0"
       ],
       "plugins": ["istanbul"]
     },
@@ -22,20 +21,18 @@
     },
     "renderer": {
       "presets": [
-        ["env", {
+        ["@babel/preset-env", {
           "modules": false
         }],
-        "stage-0"
       ]
     },
     "web": {
       "presets": [
-        ["env", {
+        ["@babel/preset-env", {
           "modules": false
         }],
-        "stage-0"
       ]
     }
   },
-  "plugins": ["transform-runtime"]
+  "plugins": ["@babel/plugin-transform-runtime"]
 }

--- a/template/.electron-vue/build.js
+++ b/template/.electron-vue/build.js
@@ -38,12 +38,6 @@ async function build () {
 
   del.sync(['dist/electron/*', '!.gitkeep'])
 
-  const tasks = ['main', 'renderer']
-  const m = new Multispinner(tasks, {
-    preText: 'building',
-    postText: 'process'
-  })
-
   let results = ''
 
   const tasks = new Listr(

--- a/template/.electron-vue/dev-runner.js
+++ b/template/.electron-vue/dev-runner.js
@@ -49,10 +49,10 @@ function startRenderer () {
     })
 
     compiler.hooks.compilation.tap('compilation', compilation => {
-      compilation.hooks.htmlWebpackPluginAfterEmit.tapAsync('html-webpack-plugin-after-emit', (data, cb) => {
+      /*compilation.hooks.htmlWebpackPluginAfterEmit.tapAsync('html-webpack-plugin-after-emit', (data, cb) => {
         hotMiddleware.publish({ action: 'reload' })
         cb()
-      })
+      })*/
     })
 
     compiler.hooks.done.tap('done', stats => {
@@ -65,6 +65,11 @@ function startRenderer () {
         contentBase: path.join(__dirname, '../'),
         quiet: true,
         hot: true,
+        compress: true,
+        liveReload: true,
+        watchOptions: {
+          ignored: /node_modules/
+        },
         before (app, ctx) {
           // app.use(hotMiddleware)
           ctx.middleware.waitUntilValid(() => {
@@ -86,7 +91,7 @@ function startMain () {
 
     compiler.hooks.watchRun.tapAsync('watch-run', (compilation, done) => {
       logStats('Main', chalk.white.bold('compiling...'))
-      hotMiddleware.publish({ action: 'compiling' })
+      // hotMiddleware.publish({ action: 'compiling' })
       done()
     })
 
@@ -128,7 +133,7 @@ function startElectron () {
   }
 
   electronProcess = spawn(electron, args)
-  
+
   electronProcess.stdout.on('data', data => {
     electronLog(data, 'blue')
   })

--- a/template/.electron-vue/webpack.main.config.js
+++ b/template/.electron-vue/webpack.main.config.js
@@ -6,7 +6,7 @@ const path = require('path')
 const { dependencies } = require('../package.json')
 const webpack = require('webpack')
 
-const MinifyPlugin = require("babel-minify-webpack-plugin")
+const TerserPlugin = require('terser-webpack-plugin')
 
 let mainConfig = {
   entry: {
@@ -64,6 +64,7 @@ let mainConfig = {
  */
 if (process.env.NODE_ENV !== 'production') {
   mainConfig.plugins.push(
+    new TerserPlugin(),
     new webpack.DefinePlugin({
       '__static': `"${path.join(__dirname, '../static').replace(/\\/g, '\\\\')}"`
     })
@@ -75,7 +76,7 @@ if (process.env.NODE_ENV !== 'production') {
  */
 if (process.env.NODE_ENV === 'production') {
   mainConfig.plugins.push(
-    new MinifyPlugin(),
+    new TerserPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"'
     })

--- a/template/.electron-vue/webpack.renderer.config.js
+++ b/template/.electron-vue/webpack.renderer.config.js
@@ -6,11 +6,11 @@ const path = require('path')
 const { dependencies } = require('../package.json')
 const webpack = require('webpack')
 
-const MinifyPlugin = require("babel-minify-webpack-plugin")
+const TerserPlugin = require('terser-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const { VueLoaderPlugin } = require('vue-loader')
+const VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 /**
  * List of node_modules to include in webpack bundle
@@ -22,7 +22,12 @@ const { VueLoaderPlugin } = require('vue-loader')
 let whiteListedModules = ['vue']
 
 let rendererConfig = {
-  devtool: '#cheap-module-eval-source-map',
+  devtool: 'eval-cheap-module-source-map',
+  optimization: {
+    minimize: true,
+    minimizer: [new TerserPlugin({
+    })],
+  },
   entry: {
     renderer: path.join(__dirname, '../src/renderer/main.js')
   },
@@ -31,6 +36,20 @@ let rendererConfig = {
   ],
   module: {
     rules: [
+      {
+        test: /\.vue$/,
+        use: {
+          loader: 'vue-loader',
+          options: {
+            extractCSS: process.env.NODE_ENV === 'production',
+            loaders: {
+              sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax=1',
+              scss: 'vue-style-loader!css-loader!sass-loader',
+              less: 'vue-style-loader!css-loader!less-loader'
+            }
+          }
+        }
+      },
 {{#if eslint}}
       {
         test: /\.(js|vue)$/,
@@ -76,24 +95,10 @@ let rendererConfig = {
         use: 'node-loader'
       },
       {
-        test: /\.vue$/,
-        use: {
-          loader: 'vue-loader',
-          options: {
-            extractCSS: process.env.NODE_ENV === 'production',
-            loaders: {
-              sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax=1',
-              scss: 'vue-style-loader!css-loader!sass-loader',
-              less: 'vue-style-loader!css-loader!less-loader'
-            }
-          }
-        }
-      },
-      {
         test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
         use: {
           loader: 'url-loader',
-          query: {
+          options: {
             limit: 10000,
             name: 'imgs/[name]--[folder].[ext]'
           }
@@ -111,7 +116,7 @@ let rendererConfig = {
         test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
         use: {
           loader: 'url-loader',
-          query: {
+          options: {
             limit: 10000,
             name: 'fonts/[name]--[folder].[ext]'
           }
@@ -152,6 +157,7 @@ let rendererConfig = {
     }),
     new webpack.NoEmitOnErrorsPlugin()
   ],
+  cache: true,
   output: {
     filename: '[name].js',
     libraryTarget: 'commonjs2',
@@ -172,6 +178,7 @@ let rendererConfig = {
  */
 if (process.env.NODE_ENV !== 'production') {
   rendererConfig.plugins.push(
+    new TerserPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.DefinePlugin({
       '__static': `"${path.join(__dirname, '../static').replace(/\\/g, '\\\\')}"`
@@ -183,17 +190,21 @@ if (process.env.NODE_ENV !== 'production') {
  * Adjust rendererConfig for production settings
  */
 if (process.env.NODE_ENV === 'production') {
-  rendererConfig.devtool = ''
+  rendererConfig.devtool = false
 
   rendererConfig.plugins.push(
-    new MinifyPlugin(),
-    new CopyWebpackPlugin([
-      {
-        from: path.join(__dirname, '../static'),
-        to: path.join(__dirname, '../dist/electron/static'),
-        ignore: ['.*']
-      }
-    ]),
+    new TerserPlugin(),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: path.join(__dirname, '../static'),
+          to: path.join(__dirname, '../dist/electron/static'),
+          globOptions: {
+            ignore: ['.*']
+          }
+        }
+      ]
+    }),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"'
     }),

--- a/template/.electron-vue/webpack.renderer.config.js
+++ b/template/.electron-vue/webpack.renderer.config.js
@@ -134,26 +134,16 @@ let rendererConfig = {
     new HtmlWebpackPlugin({
       filename: 'index.html',
       template: path.resolve(__dirname, '../src/index.ejs'),
-      templateParameters(compilation, assets, options) {
-        return {
-          compilation: compilation,
-          webpack: compilation.getStats().toJson(),
-          webpackConfig: compilation.options,
-          htmlWebpackPlugin: {
-            files: assets,
-            options: options,
-          },
-          process,
-        };
-      },
       minify: {
         collapseWhitespace: true,
         removeAttributeQuotes: true,
         removeComments: true
       },
+      isBrowser: false,
+      isDevelopment: process.env.NODE_ENV !== 'production',
       nodeModules: process.env.NODE_ENV !== 'production'
-        ? path.resolve(__dirname, '../node_modules')
-        : false
+          ? path.resolve(__dirname, '../node_modules')
+          : false
     }),
     new webpack.NoEmitOnErrorsPlugin()
   ],

--- a/template/.electron-vue/webpack.web.config.js
+++ b/template/.electron-vue/webpack.web.config.js
@@ -5,7 +5,7 @@ process.env.BABEL_ENV = 'web'
 const path = require('path')
 const webpack = require('webpack')
 
-const MinifyPlugin = require("babel-minify-webpack-plugin")
+const TerserPlugin = require('terser-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
@@ -77,7 +77,7 @@ let webConfig = {
         test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
         use: {
           loader: 'url-loader',
-          query: {
+          options: {
             limit: 10000,
             name: 'imgs/[name].[ext]'
           }
@@ -144,17 +144,21 @@ let webConfig = {
  * Adjust webConfig for production settings
  */
 if (process.env.NODE_ENV === 'production') {
-  webConfig.devtool = ''
+  webConfig.devtool = false
 
   webConfig.plugins.push(
-    new MinifyPlugin(),
-    new CopyWebpackPlugin([
-      {
-        from: path.join(__dirname, '../static'),
-        to: path.join(__dirname, '../dist/web/static'),
-        ignore: ['.*']
-      }
-    ]),
+    new TerserPlugin(),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: path.join(__dirname, '../static'),
+          to: path.join(__dirname, '../dist/web/static'),
+          globOptions: {
+            ignore: ['.*']
+          }
+        }
+      ]
+    }),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"'
     }),

--- a/template/.electron-vue/webpack.web.config.js
+++ b/template/.electron-vue/webpack.web.config.js
@@ -87,7 +87,7 @@ let webConfig = {
         test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
         use: {
           loader: 'url-loader',
-          query: {
+          options: {
             limit: 10000,
             name: 'fonts/[name].[ext]'
           }
@@ -101,24 +101,16 @@ let webConfig = {
     new HtmlWebpackPlugin({
       filename: 'index.html',
       template: path.resolve(__dirname, '../src/index.ejs'),
-      templateParameters(compilation, assets, options) {
-        return {
-          compilation: compilation,
-          webpack: compilation.getStats().toJson(),
-          webpackConfig: compilation.options,
-          htmlWebpackPlugin: {
-            files: assets,
-            options: options,
-          },
-          process,
-        };
-      },
       minify: {
         collapseWhitespace: true,
         removeAttributeQuotes: true,
         removeComments: true
       },
-      nodeModules: false
+      isBrowser: false,
+      isDevelopment: process.env.NODE_ENV !== 'production',
+      nodeModules: process.env.NODE_ENV !== 'production'
+          ? path.resolve(__dirname, '../node_modules')
+          : false
     }),
     new webpack.DefinePlugin({
       'process.env.IS_WEB': 'true'

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -1,8 +1,8 @@
 module.exports = {
   root: true,
-  parser: 'babel-eslint',
   parserOptions: {
-    sourceType: 'module'
+    parser: 'babel-eslint',
+    sourceType: 'module',
   },
   env: {
     browser: true,
@@ -20,7 +20,7 @@ module.exports = {
   plugins: [
     'html'
   ],
-  'rules': {
+  rules: {
     {{#if_eq eslintConfig 'standard'}}
     // allow paren-less arrow functions
     'arrow-parens': 0,

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
     node: true
   },
   {{#if_eq eslintConfig 'standard'}}
-  extends: 'standard',
+  extends: ['standard', 'plugin:vue/base'],
   {{/if_eq}}
   {{#if_eq eslintConfig 'airbnb'}}
   extends: 'airbnb-base',

--- a/template/package.json
+++ b/template/package.json
@@ -77,55 +77,52 @@
   },
 {{/if_eq}}
   "dependencies": {
-    "vue": "^2.5.16"{{deps plugins}}
+    "vue": "^2.6.14"{{deps plugins}}
   },
   "devDependencies": {
-    "ajv": "^6.5.0",
-    "babel-core": "^6.26.3",
-    "babel-loader": "^7.1.4",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-stage-0": "^6.24.1",
-    "babel-register": "^6.26.0",
-    "babel-minify-webpack-plugin": "^0.3.1",
+    "ajv": "^8.6.0",
+    "@babel/core": "^7.14.3",
+    "@babel/plugin-transform-runtime": "^7.14.3",
+    "@babel/preset-env": "^7.14.4",
+    "@babel/register": "^7.13.16",
+    "babel-loader": "^8.2.2",
     "cfonts": "^2.1.2",
-    "chalk": "^2.4.1",
-    "copy-webpack-plugin": "^4.5.1",
-    "cross-env": "^5.1.6",
-    "css-loader": "^0.28.11",
-    "del": "^3.0.0",
+    "chalk": "^4.1.1",
+    "copy-webpack-plugin": "^9.0.0",
+    "cross-env": "^7.0.3",
+    "css-loader": "^5.2.6",
+    "del": "^6.0.0",
     "devtron": "^1.4.0",
-    "electron": "^2.0.4",
-    "electron-debug": "^1.5.0",
-    "electron-devtools-installer": "^2.2.4",
+    "electron": "^13.1.1",
+    "electron-debug": "^3.2.0",
+    "electron-devtools-installer": "^3.2.0",
     {{#if_eq builder 'packager'}}
-    "electron-packager": "^12.1.0",
-    "electron-rebuild": "^1.8.1",
+    "electron-packager": "^15.2.0",
+    "electron-rebuild": "^2.3.5",
     {{else}}
-    "electron-builder": "^20.19.2",
+    "electron-builder": "^22.11.5",
     {{/if_eq}}
     {{#eslint}}
-    "babel-eslint": "^8.2.3",
-    "eslint": "^4.19.1",
+    "babel-eslint": "^10.1.0",
+    "eslint": "^7.28.0",
     "eslint-friendly-formatter": "^4.0.1",
-    "eslint-loader": "^2.0.0",
-    "eslint-plugin-html": "^4.0.3",
+    "eslint-loader": "^4.0.2",
+    "eslint-plugin-html": "^6.1.2",
     {{#if_eq eslintConfig 'standard'}}
-    "eslint-config-standard": "^11.0.0",
-    "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.8.0",
-    "eslint-plugin-standard": "^3.1.0",
+    "eslint-config-standard": "^16.0.3",
+    "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0",
     {{/if_eq}}
     {{#if_eq eslintConfig 'airbnb'}}
-    "eslint-config-airbnb-base": "^12.1.0",
-    "eslint-import-resolver-webpack": "^0.10.0",
-    "eslint-plugin-import": "^2.12.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-import-resolver-webpack": "^0.13.1",
+    "eslint-plugin-import": "^2.23.4",
     {{/if_eq}}
     {{/eslint}}
-    "mini-css-extract-plugin": "0.4.0",
-    "file-loader": "^1.1.11",
-    "html-webpack-plugin": "^3.2.0",
+    "mini-css-extract-plugin": "1.6.0",
+    "file-loader": "^6.2.0",
+    "html-webpack-plugin": "^5.3.1",
     {{#if unit}}
     "inject-loader": "^4.0.1",
     "karma": "^2.0.2",
@@ -143,25 +140,26 @@
     "spectron": "^3.8.0",
     {{/if}}
     {{#testing unit e2e}}
-    "babel-plugin-istanbul": "^4.1.6",
+    "babel-plugin-istanbul": "^6.0.0",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
     {{/testing}}
-    "node-loader": "^0.6.0",
+    "node-loader": "^2.0.0",
     {{#if usesass}}
-    "node-sass": "^4.9.2",
-    "sass-loader": "^7.0.3",
+    "node-sass": "^6.0.1",
+    "sass-loader": "^12.1.0",
     {{/if}}
-    "style-loader": "^0.21.0",
-    "url-loader": "^1.0.1",
+    "style-loader": "^3.0.0",
+    "terser-webpack-plugin": "5.1.3",
+    "url-loader": "^4.1.1",
     "vue-html-loader": "^1.2.4",
-    "vue-loader": "^15.2.4",
-    "vue-style-loader": "^4.1.0",
-    "vue-template-compiler": "^2.5.16",
-    "webpack-cli": "^3.0.8",
-    "webpack": "^4.15.1",
-    "webpack-dev-server": "^3.1.4",
-    "webpack-hot-middleware": "^2.22.2",
-    "webpack-merge": "^4.1.3"
+    "vue-loader": "^15.9.7",
+    "vue-style-loader": "^4.1.3",
+    "vue-template-compiler": "^2.6.14",
+    "webpack-cli": "^4.7.2",
+    "webpack": "^5.38.1",
+    "webpack-dev-server": "^3.11.2",
+    "webpack-hot-middleware": "^2.25.0",
+    "webpack-merge": "^5.8.0"
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -108,6 +108,7 @@
     "eslint-friendly-formatter": "^4.0.1",
     "eslint-loader": "^4.0.2",
     "eslint-plugin-html": "^6.1.2",
+    "eslint-plugin-vue": "^7.12.1",
     {{#if_eq eslintConfig 'standard'}}
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.23.4",

--- a/template/src/index.ejs
+++ b/template/src/index.ejs
@@ -13,9 +13,9 @@
   <body>
     <div id="app"></div>
     <!-- Set `__static` path to static files in production -->
-    <% if (!process.browser) { %>
+    <% if (!htmlWebpackPlugin.options.isBrowser && !htmlWebpackPlugin.options.isDevelopment) { %>
       <script>
-        if (process.env.NODE_ENV !== 'development') window.__static = require('path').join(__dirname, '/static').replace(/\\/g, '\\\\')
+        window.__static = require('path').join(__dirname, '/static').replace(/\\/g, '\\\\')
       </script>
     <% } %>
 

--- a/template/src/main/index.js
+++ b/template/src/main/index.js
@@ -18,7 +18,7 @@ if (process.env.NODE_ENV !== 'development') {
 let mainWindow
 const winURL = process.env.NODE_ENV === 'development'
   ? `http://localhost:9080`
-  : `file://${__dirname}/index.html`
+  : require('path').join('file://', __dirname, path.sep, 'index.html')
 
 function createWindow () {
   /**

--- a/template/src/main/index.js
+++ b/template/src/main/index.js
@@ -5,6 +5,7 @@
 import { app, BrowserWindow } from 'electron'{{#if_eq eslintConfig 'airbnb'}} // eslint-disable-line{{/if_eq}}
 {{#isEnabled plugins 'vuex-electron'}}
 import '../renderer/store'
+import * as path from 'path'
 {{/isEnabled}}
 
 /**
@@ -12,13 +13,13 @@ import '../renderer/store'
  * https://simulatedgreg.gitbooks.io/electron-vue/content/en/using-static-assets.html
  */
 if (process.env.NODE_ENV !== 'development') {
-  global.__static = require('path').join(__dirname, '/static').replace(/\\/g, '\\\\'){{#if_eq eslintConfig 'airbnb'}} // eslint-disable-line{{/if_eq}}
+  global.__static = path.join(__dirname, '/static').replace(/\\/g, '\\\\'){{#if_eq eslintConfig 'airbnb'}} // eslint-disable-line{{/if_eq}}
 }
 
 let mainWindow
 const winURL = process.env.NODE_ENV === 'development'
   ? `http://localhost:9080`
-  : require('path').join('file://', __dirname, path.sep, 'index.html')
+  : path.join('file://', __dirname, path.sep, 'index.html')
 
 function createWindow () {
   /**
@@ -27,7 +28,12 @@ function createWindow () {
   mainWindow = new BrowserWindow({
     height: 563,
     useContentSize: true,
-    width: 1000
+    width: 1000,
+    webPreferences: {
+      nodeIntegration: true,
+      nodeIntegrationInWorker: true,
+      enableRemoteModule: true
+    }
   })
 
   mainWindow.loadURL(winURL)

--- a/template/src/main/index.js
+++ b/template/src/main/index.js
@@ -30,6 +30,7 @@ function createWindow () {
     useContentSize: true,
     width: 1000,
     webPreferences: {
+      contextIsolation: false,
       nodeIntegration: true,
       nodeIntegrationInWorker: true,
       enableRemoteModule: true

--- a/template/src/renderer/App.vue
+++ b/template/src/renderer/App.vue
@@ -11,18 +11,18 @@
 <script>
 {{#isEnabled plugins 'vue-router'}}
 {{else}}
-  import LandingPage from '@/components/LandingPage'
+import LandingPage from '@/components/LandingPage'
 
 {{/isEnabled}}
-  export default {
-    name: '{{ name }}'{{#isEnabled plugins 'vue-router'}}{{else}},{{/isEnabled}}
+export default {
+  name: '{{ name }}'{{#isEnabled plugins 'vue-router'}}{{else}},{{/isEnabled}}
 {{#isEnabled plugins 'vue-router'}}
 {{else}}
-    components: {
-      LandingPage
-    }
-{{/isEnabled}}
+  components: {
+    LandingPage
   }
+{{/isEnabled}}
+}
 </script>
 
 <style>

--- a/template/src/renderer/components/LandingPage.vue
+++ b/template/src/renderer/components/LandingPage.vue
@@ -30,17 +30,17 @@
 </template>
 
 <script>
-  import SystemInformation from './LandingPage/SystemInformation'
+import SystemInformation from './LandingPage/SystemInformation'
 
-  export default {
-    name: 'landing-page',
-    components: { SystemInformation },
-    methods: {
-      open (link) {
-        {{#isEnabled plugins 'vue-electron'}}this.$electron{{else}}require('electron'){{/isEnabled}}.shell.openExternal(link)
-      }
+export default {
+  name: 'landing-page',
+  components: { SystemInformation },
+  methods: {
+    open (link) {
+      {{#isEnabled plugins 'vue-electron'}}this.$electron{{else}}require('electron'){{/isEnabled}}.shell.openExternal(link)
     }
   }
+}
 </script>
 
 <style>

--- a/template/src/renderer/components/LandingPage/SystemInformation.vue
+++ b/template/src/renderer/components/LandingPage/SystemInformation.vue
@@ -33,22 +33,22 @@
 </template>
 
 <script>
-  export default {
-    data () {
-      return {
-        electron: process.versions.electron,
-        {{#isEnabled plugins 'vue-router'}}
-        name: this.$route.name,
-        {{/isEnabled}}
-        node: process.versions.node,
-        {{#isEnabled plugins 'vue-router'}}
-        path: this.$route.path,
-        {{/isEnabled}}
-        platform: require('os').platform(),
-        vue: require('vue/package.json').version
-      }
+export default {
+  data () {
+    return {
+      electron: process.versions.electron,
+      {{#isEnabled plugins 'vue-router'}}
+      name: this.$route.name,
+      {{/isEnabled}}
+      node: process.versions.node,
+      {{#isEnabled plugins 'vue-router'}}
+      path: this.$route.path,
+      {{/isEnabled}}
+      platform: require('os').platform(),
+      vue: require('vue/package.json').version
     }
   }
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
This commit is for upgrading outdated packages, upgrading to Babel 7 and Webpack 5.

By applying Babel 7 and Webpack 5, build and hot-reload speed improvements have been greatly improved.

## Changes
- ✅ Package dependency upgrade (Includes Babel, Webpack, ESLint, Other outdated packages...)
- ✅ Fixed npm run dev and npm run build errors
- ✅ Perhaps the requirements of the basic Node version have been raised. (Tested on Node 14.17)
- ✅ Fix Hot Reload module behavior problem
- ✅ Upgrade to the latest Electron specs

## TODO
- Document(README.md) update

Unit test related modules will be the same. I haven't checked separately.
